### PR TITLE
Fix lingering mixer head after placing any mixer (1.20.1)

### DIFF
--- a/src/main/java/fr/iglee42/createcasing/mixins/create/client/MixerVisualMixin.java
+++ b/src/main/java/fr/iglee42/createcasing/mixins/create/client/MixerVisualMixin.java
@@ -1,48 +1,27 @@
 package fr.iglee42.createcasing.mixins.create.client;
 
-import com.simibubi.create.AllPartialModels;
-import com.simibubi.create.content.kinetics.base.RotatingInstance;
 import com.simibubi.create.content.kinetics.base.SingleAxisRotatingVisual;
 import com.simibubi.create.content.kinetics.mixer.MechanicalMixerBlockEntity;
 import com.simibubi.create.content.kinetics.mixer.MixerVisual;
-import com.simibubi.create.foundation.render.AllInstanceTypes;
 import dev.engine_room.flywheel.api.model.Model;
 import dev.engine_room.flywheel.api.visualization.VisualizationContext;
 import dev.engine_room.flywheel.lib.model.Models;
+import dev.engine_room.flywheel.lib.model.baked.PartialModel;
 import fr.iglee42.createcasing.registries.EncasedPartialModels;
-import net.minecraft.core.Direction;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(value = MixerVisual.class,remap = false)
 public abstract class MixerVisualMixin extends SingleAxisRotatingVisual<MechanicalMixerBlockEntity> {
-
-    @Mutable
-    @Shadow
-    @Final
-    private RotatingInstance mixerHead;
-
-    @Shadow
-    protected abstract void animate(float pt);
 
     public MixerVisualMixin(VisualizationContext context, MechanicalMixerBlockEntity blockEntity, float partialTick, Model model) {
         super(context, blockEntity, partialTick, model);
     }
 
-
-    @Inject(method = "<init>",at = @At(value = "RETURN"))
-    private void encased$modifyHead(VisualizationContext context, MechanicalMixerBlockEntity blockEntity, float partialTick, CallbackInfo ci){
-        mixerHead = instancerProvider().instancer(AllInstanceTypes.ROTATING, Models.partial(EncasedPartialModels.getMixerHead(blockEntity.getBlockState())))
-                .createInstance();
-
-        mixerHead.setRotationAxis(Direction.Axis.Y);
-
-        animate(partialTick);
+    @Redirect(method = "<init>",at= @At(value = "INVOKE", target = "Ldev/engine_room/flywheel/lib/model/Models;partial(Ldev/engine_room/flywheel/lib/model/baked/PartialModel;)Ldev/engine_room/flywheel/api/model/Model;",ordinal = 1))
+    private Model encased$replaceHeadModel(PartialModel partial){
+        return Models.partial(EncasedPartialModels.getMixerHead(blockEntity.getBlockState()));
     }
 
 }


### PR DESCRIPTION
This is caused by MixerVisualMixin not deleting the previous instance assigned to mixerHead, leaving a dangling reference. Both 1.21.1 and 1.20.1 do this, but it only causes a visible problem on 1.20.1.

<img width="854" height="480" alt="2026-01-12_02 26 53" src="https://github.com/user-attachments/assets/268a637d-5ffa-4c59-a283-00ad9f398ad3" />
