### PR TITLE
Add missing Vertical Gearbox recipes for all casing variants

### DIFF
--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/brass_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/brass_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:brass_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/brass_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/brass_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/copper_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/copper_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:copper_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/copper_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/copper_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/creative_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/creative_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "createcasing:creative_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/creative_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/creative_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/industrial_iron_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/industrial_iron_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:industrial_iron_block"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/industrial_iron_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/industrial_iron_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/railway_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/railway_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:railway_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/railway_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/railway_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/refined_radiance_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/refined_radiance_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:refined_radiance_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/refined_radiance_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/refined_radiance_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/shadow_steel_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/shadow_steel_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:shadow_steel_casing"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/shadow_steel_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/shadow_steel_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/weathered_iron_vertical.json
+++ b/src/generated/resources/data/createcasing/advancement/recipes/misc/crafting/gearbox/weathered_iron_vertical.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "create:weathered_iron_block"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "createcasing:crafting/gearbox/weathered_iron_vertical"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "createcasing:crafting/gearbox/weathered_iron_vertical"
+    ]
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/brass_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/brass_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:brass_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_brass_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/copper_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/copper_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:copper_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_copper_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/creative_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/creative_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "createcasing:creative_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_creative_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/industrial_iron_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/industrial_iron_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:industrial_iron_block"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_industrial_iron_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/railway_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/railway_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:railway_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_railway_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/refined_radiance_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/refined_radiance_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:refined_radiance_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_refined_radiance_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/shadow_steel_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/shadow_steel_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:shadow_steel_casing"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_shadow_steel_gearbox"
+  }
+}

--- a/src/generated/resources/data/createcasing/recipe/crafting/gearbox/weathered_iron_vertical.json
+++ b/src/generated/resources/data/createcasing/recipe/crafting/gearbox/weathered_iron_vertical.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "item": "create:cogwheel"
+    },
+    "C": {
+      "item": "create:weathered_iron_block"
+    }
+  },
+  "pattern": [
+    "B B",
+    " C ",
+    "B B"
+  ],
+  "result": {
+    "count": 1,
+    "id": "createcasing:vertical_weathered_iron_gearbox"
+  }
+}

--- a/src/main/java/fr/iglee42/createcasing/registries/EncasedRecipeGens.java
+++ b/src/main/java/fr/iglee42/createcasing/registries/EncasedRecipeGens.java
@@ -351,6 +351,14 @@ public class EncasedRecipeGens extends BaseRecipeProvider{
                 sh.requires(set.getVerticalGearboxItem())
         ));
 
+        createForSetElement("gearbox",CasingSet::doesGenerateGearbox,CasingSet::getVerticalGearboxItem,(builder,set)->builder.suffix("_vertical").viaShaped(sh->
+                sh.pattern("B B")
+                        .pattern(" C ")
+                        .pattern("B B")
+                        .define('B', AllBlocks.COGWHEEL)
+                        .define('C',set.getCasing())
+        ));
+
         createForSetElement("gearbox",CasingSet::doesGenerateGearbox,CasingSet::getVerticalGearboxItem,(builder,set)->builder.suffix("_vertical_from_conversion").viaShapeless(sh->
                 sh.requires(set.getGearbox())
         ));

--- a/src/main/resources/assets/createcasing/lang/zh_cn.json
+++ b/src/main/resources/assets/createcasing/lang/zh_cn.json
@@ -162,7 +162,7 @@
   "block.createcasing.creative_casing": "创造机壳",
   "block.createcasing.creative_chain_conveyor": "创造锁链传动轮",
   "block.createcasing.creative_clutch": "创造离合器",
-  "block.createcasing.creative_cogwheel": "创造齿轮",
+  "block.createcasing.creative_cogwheel": "创造齿轮箱",
   "block.createcasing.creative_configurable_gearbox": "创造可调节十字齿轮箱",
   "block.createcasing.creative_deployer": "创造机械手",
   "block.createcasing.creative_depot": "创造置物台",


### PR DESCRIPTION
Just like Create's (Andesite) Vertical Gearbox recipe:
<img width="933" height="309" alt="Andesite Vertical Gearbox" src="https://github.com/user-attachments/assets/b5ebbe54-06cd-41fe-ae59-1a8837cbc9c0" />

We add these recipes for all casing variant Vertical Gearbox:

<img width="1081" height="343" alt="Brass Vertical Gearbox" src="https://github.com/user-attachments/assets/691ead8d-fd37-414f-a791-b2e9e31441ee" />

We also fix a little spell mistake in #164.