### PR TITLE
Fix chorium ingot recipe json

### DIFF
--- a/src/main/resources/data/createcasing/recipe/sequenced_assembly/chorium_ingot.json
+++ b/src/main/resources/data/createcasing/recipe/sequenced_assembly/chorium_ingot.json
@@ -17,7 +17,7 @@
           "item": "createcasing:processing_chorium"
         },
         {
-          "type": "fluid_stack",
+          "type": "neoforge:single",
           "amount": 500,
           "fluid": "minecraft:lava"
         }


### PR DESCRIPTION
I created an issue here: https://github.com/iglee42/CreateCasing/issues/202
I think this fixes the issue. I put a copy of this recipe into a pack without create encased and swapped types to generic minecraft types. I confirmed the same error occured.
Then I changed the syntax to neoforge:single and the error disappeared. Feel free to close this PR if you are not happy with it.